### PR TITLE
Replace commonmark with marko

### DIFF
--- a/lettersmith/markdowntools.py
+++ b/lettersmith/markdowntools.py
@@ -1,9 +1,9 @@
-from commonmark import commonmark
+from marko import Markdown
 from lettersmith.html import strip_html
 from lettersmith import docs as Docs
 from lettersmith.func import compose
 
 
-markdown = commonmark
+markdown = Markdown(extensions=['footnote'])
 strip_markdown = compose(strip_html, markdown)
 content = Docs.renderer(markdown)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=("tests", "tests.*")),
     install_requires=[
         "PyYAML>=3.13",
-        "commonmark>=0.9.1",
+        "marko>=1.3.0",
         "python-frontmatter>=0.3.1",
         "Jinja2>=2.7"
         # TODO


### PR DESCRIPTION
Adds in the ability to use footnotes. Currently haven't been able to figure out how to get [the TOC extension](https://marko-py.readthedocs.io/en/latest/extensions.html#toc-extension) to output in documents, so I've excluded it from this.